### PR TITLE
fix for timeouts issue

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -130,7 +130,8 @@ exports.config = {
     // Options to be passed to Mocha.
     // See the full list at http://mochajs.org/
     mochaOpts: {
-        ui: 'bdd'
+        ui: 'bdd',
+        timeout: 30000
     },
     //
     // =====


### PR DESCRIPTION
without this change, I get the following errors when I run [File Generation](https://github.com/madeofsun/label-them-sites-provider/blob/master/docs/TaskGeneration.md#file-generation)

```
> wdio-test@1.0.0 start /home/alnedorezov/Projects/js/label-them-sites-provider
> wdio wdio.conf.js


[13:42:40]  COMMAND	POST 	 "/wd/hub/session"
[13:42:40]  DATA		{"desiredCapabilities":{"javascriptEnabled":true,"locationContextEnabled":true,"handlesAlerts":true,"rotatable":true,"maxInstances":5,"browserName":"chrome","loggingPrefs":{"browser":"ALL","driver":"ALL"},"requestOrigins":{"url":"http://webdriver.io","version":"4.14.4","name":"webdriverio"}}}
[13:42:41]  INFO	SET SESSION ID 11155e4e2809bb647d2b102fdbee69ca
[13:42:41]  RESULT		{"acceptInsecureCerts":false,"browserName":"chrome","browserVersion":"75.0.3770.90","chrome":{"chromedriverVersion":"75.0.3770.90 (a6dcaf7e3ec6f70a194cc25e8149475c6590e025-refs/branch-heads/3770@{#1003})","userDataDir":"/tmp/.com.google.Chrome.IB9cc5"},"goog:chromeOptions":{"debuggerAddress":"localhost:39809"},"networkConnectionEnabled":false,"pageLoadStrategy":"normal","platformName":"linux","proxy":{},"setWindowRect":true,"strictFileInteractability":false,"timeouts":{"implicit":0,"pageLoad":300000,"script":30000},"unhandledPromptBehavior":"dismiss and notify","webdriver.remote.sessionid":"11155e4e2809bb647d2b102fdbee69ca"}
FFFFFF[13:42:41]  COMMAND	DELETE 	 "/wd/hub/session/11155e4e2809bb647d2b102fdbee69ca"
[13:42:41]  DATA		{}


0 passing (1.90s)
6 failing

1) loop over urls process single url:
browser.setTimeout is not a function
running chrome
TypeError: browser.setTimeout is not a function
    at Context.<anonymous> (/home/alnedorezov/Projects/js/label-them-sites-provider/test/specs/first.js:21:15)
    at new Promise (<anonymous>)
    at new F (/home/alnedorezov/Projects/js/label-them-sites-provider/node_modules/core-js/library/modules/_export.js:36:28)

2) loop over urls process single url:
browser.setTimeout is not a function
running chrome
TypeError: browser.setTimeout is not a function
    at Context.<anonymous> (/home/alnedorezov/Projects/js/label-them-sites-provider/test/specs/first.js:21:15)
    at new Promise (<anonymous>)
    at new F (/home/alnedorezov/Projects/js/label-them-sites-provider/node_modules/core-js/library/modules/_export.js:36:28)

3) loop over urls process single url:
browser.setTimeout is not a function
running chrome
TypeError: browser.setTimeout is not a function
    at Context.<anonymous> (/home/alnedorezov/Projects/js/label-them-sites-provider/test/specs/first.js:21:15)
    at new Promise (<anonymous>)
    at new F (/home/alnedorezov/Projects/js/label-them-sites-provider/node_modules/core-js/library/modules/_export.js:36:28)

4) loop over urls process single url:
browser.setTimeout is not a function
running chrome
TypeError: browser.setTimeout is not a function
    at Context.<anonymous> (/home/alnedorezov/Projects/js/label-them-sites-provider/test/specs/first.js:21:15)
    at new Promise (<anonymous>)
    at new F (/home/alnedorezov/Projects/js/label-them-sites-provider/node_modules/core-js/library/modules/_export.js:36:28)

5) loop over urls process single url:
browser.setTimeout is not a function
running chrome
TypeError: browser.setTimeout is not a function
    at Context.<anonymous> (/home/alnedorezov/Projects/js/label-them-sites-provider/test/specs/first.js:21:15)
    at new Promise (<anonymous>)
    at new F (/home/alnedorezov/Projects/js/label-them-sites-provider/node_modules/core-js/library/modules/_export.js:36:28)

6) loop over urls process single url:
browser.setTimeout is not a function
running chrome
TypeError: browser.setTimeout is not a function
    at Context.<anonymous> (/home/alnedorezov/Projects/js/label-them-sites-provider/test/specs/first.js:21:15)
    at new Promise (<anonymous>)
    at new F (/home/alnedorezov/Projects/js/label-them-sites-provider/node_modules/core-js/library/modules/_export.js:36:28)



npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! wdio-test@1.0.0 start: `wdio wdio.conf.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the wdio-test@1.0.0 start script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/alnedorezov/.npm/_logs/2019-07-04T10_42_41_898Z-debug.log

```